### PR TITLE
Update the github actions runner within the container

### DIFF
--- a/github-actions-runner/Dockerfile
+++ b/github-actions-runner/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/evryfs/github-actions-runner:ubuntu20-20201210.0-2.275.1
 
 USER root
-RUN apt-get update && \
+RUN sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com && \
+    apt-get update && \
     apt-get -y install gcc libpython3-dev && \
     apt-get -y clean && \
     rm -rf /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/github-actions-runner/Dockerfile
+++ b/github-actions-runner/Dockerfile
@@ -1,9 +1,15 @@
-FROM quay.io/evryfs/github-actions-runner:ubuntu20-20201210.0-2.277.1
+FROM quay.io/evryfs/github-actions-runner:ubuntu20-20201210.0-2.275.1
 
 USER root
 RUN apt-get update && \
     apt-get -y install gcc libpython3-dev && \
     apt-get -y clean && \
     rm -rf /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Update latest runner
+ARG RUNNER_VERSION=2.277.1
+RUN curl -sL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" | tar xzvC /home/runner && \
+    /home/runner/bin/installdependencies.sh
+
 RUN echo "runner ALL=(root) NOPASSWD: /usr/bin/apt-get*" > /etc/sudoers.d/runner
 USER runner


### PR DESCRIPTION
This was @pcm32 's plan to address issues with the latest version of the upstream container, specifically compatibility with the github actions operator we're using on our k8s cluster, which is currently limited to an older kubernetes version. This PR updates the software within the container to the latest, without updating the upstream container, which seems to work.