### PR TITLE
Add automerge for github runner updates

### DIFF
--- a/.github/workflows/github-actions-runner-detect-release.yaml
+++ b/.github/workflows/github-actions-runner-detect-release.yaml
@@ -22,6 +22,7 @@ jobs:
         run: |
           sed -i "s/ARG RUNNER_VERSION=$CURRENT_VERSION/ARG RUNNER_VERSION=$RELEASE_NO/" github-actions-runner/Dockerfile  
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: Update actions runner to ${{ steps.getrelease.outputs.release_tag }}
@@ -36,3 +37,11 @@ jobs:
           labels: dependencies, automated pr
           branch: actions-runner-updates
           reviewers: pinin4fjords,pcm32
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.PAT }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/github-actions-runner-detect-release.yaml
+++ b/.github/workflows/github-actions-runner-detect-release.yaml
@@ -45,3 +45,10 @@ jobs:
           token: ${{ secrets.PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
+          
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.PAT }}
+          number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
Currently we have to approve merges on runner updates, which means things break if someone misses the PR. Now we know this works, we can allow auto merge.

- [x] Generate PAT and add to secrets
- [x] Enable auto-merge on repo