### PR TITLE
Fix flyway executability

### DIFF
--- a/atlas-schemas-base/post_install_dockerfile
+++ b/atlas-schemas-base/post_install_dockerfile
@@ -1,6 +1,9 @@
 
 USER root
 RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.3.2/flyway-commandline-6.3.2-linux-x64.tar.gz | tar xvz && ln -s `pwd`/flyway-6.3.2/flyway /usr/local/bin
+# needed since atlas-schemas will copy stuff there
+RUN chmod a+w /usr/local
+RUN chown micromamba /usr/local/bin/flyway
 USER micromamba
 
 ENV PATH "/bin:/sbin:/usr/bin:/usr/local/bin:/opt/conda/bin"


### PR DESCRIPTION
This ensures that the flyway binary can be executed by the user that runs the tests, and that atlas-schemas test processes can put the required elements in place.