### PR TITLE
Update base image for runner

### DIFF
--- a/github-actions-runner/Dockerfile
+++ b/github-actions-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/evryfs/github-actions-runner:ubuntu20-20210628.1-2.278.0
+FROM quay.io/evryfs/github-actions-runner:ubuntu20-20211108.1
 
 USER root
 RUN sudo apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com && \


### PR DESCRIPTION
This updates the base runner image to address the issue exhibited in https://github.com/ebi-gene-expression-group/atlas-containers/runs/4150838229?check_suite_focus=true.

Note that the image no longer has the runner version appended. 