### PR TITLE
Atlas analysis deps

### DIFF
--- a/atlas-analysis-base/image_tag
+++ b/atlas-analysis-base/image_tag
@@ -1,1 +1,1 @@
-atlas-analysis-base:0.0.1
+atlas-analysis-base:0.0.2

--- a/atlas-analysis-base/templated-conda-env.yaml
+++ b/atlas-analysis-base/templated-conda-env.yaml
@@ -9,6 +9,8 @@ dependencies:
   - r-base
   - bats-core
   - r-atlas-internal
+  - r-reshape2
   - bioconductor-biobase 
   - bioconductor-genefilter
   - bioconductor-limma
+  - bioconductor-deseq2


### PR DESCRIPTION
This PR adds dependencies to atlas-analysis-base:

 - bioconductor-deseq2 - this should have been there in the first place, being essential for RNA-seq analysis
 - r-reshape2 - allows significant simplification of differential expression code being proposed in https://github.com/ebi-gene-expression-group/atlas-analysis/pull/1