### PR TITLE
Add remaining atlas-analysis R deps

### DIFF
--- a/atlas-analysis-base/templated-conda-env.yaml
+++ b/atlas-analysis-base/templated-conda-env.yaml
@@ -14,3 +14,9 @@ dependencies:
   - bioconductor-genefilter
   - bioconductor-limma
   - bioconductor-deseq2
+  - r-optparse
+  - r-bit
+  - r-ggplot2
+  - r-gplots
+  - r-rcolorbrewer
+  - bioconductor-clusterseq


### PR DESCRIPTION
This PR adds the remaining R dependencies for atlas-analysis, from grep'ing that codebase for 'library('. 