### PR TITLE
Pin atlas-web-bulk to 36.1.0 and update atlas-index-base

### DIFF
--- a/atlas-index-base/image_tag
+++ b/atlas-index-base/image_tag
@@ -1,1 +1,1 @@
-atlas-index-base:1.0
+atlas-index-base:1.1

--- a/atlas-index-base/templated-conda-env.yaml
+++ b/atlas-index-base/templated-conda-env.yaml
@@ -9,4 +9,4 @@ dependencies:
   - jq
   - pyyaml
   - pandas
-  - atlas-web-bulk-cli
+  - atlas-web-bulk-cli =36.1.0


### PR DESCRIPTION
As it says on the tin. To expose experiment design update and coexpression update through the CLI.