### PR TITLE
add container for export r deps

### DIFF
--- a/data-export-bulk-r-base/image_tag
+++ b/data-export-bulk-r-base/image_tag
@@ -1,0 +1,1 @@
+data-export-bulk-r-base:0.0.1

--- a/data-export-bulk-r-base/templated-conda-env.yaml
+++ b/data-export-bulk-r-base/templated-conda-env.yaml
@@ -1,0 +1,16 @@
+name: data-export-bulk-r-base
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+  - ebi-gene-expression-group
+dependencies:
+  - bioconductor-edaseq
+  - bioconductor-ruvseq
+  - bioconductor-s4vectors
+  - bioconductor-summarizedexperiment
+  - r-funr
+  - r-ggfortify
+  - r-ggplot2
+  - r-optparse
+  - r-rcolorbrewer


### PR DESCRIPTION
This PR adds a container with deps for the r-based exports in https://github.com/ebi-gene-expression-group/data-exports-bulk, principally https://github.com/ebi-gene-expression-group/data-exports-bulk/blob/develop/bin/export_ot_baseline_metaanalysis.sh. 