### PR TITLE
Add container with ot export deps

### DIFF
--- a/data-export-bulk-opentargets/image_tag
+++ b/data-export-bulk-opentargets/image_tag
@@ -1,0 +1,1 @@
+data-export-bulk-opentargets:0.0.1

--- a/data-export-bulk-opentargets/templated-conda-env.yaml
+++ b/data-export-bulk-opentargets/templated-conda-env.yaml
@@ -1,0 +1,12 @@
+name: data-export-bulk-r-base
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+  - ebi-gene-expression-group
+dependencies:
+  - opentargets-validator
+  - coreutils
+  - jq
+  - curl
+  - gzip 

--- a/data-export-bulk-opentargets/templated-conda-env.yaml
+++ b/data-export-bulk-opentargets/templated-conda-env.yaml
@@ -5,7 +5,7 @@ channels:
   - bioconda
   - ebi-gene-expression-group
 dependencies:
-  - opentargets-validator
+  - opentargets-validator=0.7.0
   - coreutils
   - jq
   - curl


### PR DESCRIPTION
The OT export process is lacking a few deps in the Bioconda opentargets-validator container. So let's make our own.