### PR TITLE
Build an iRAP fedora container and push to quay.io

### DIFF
--- a/.github/workflows/irap-fedora-ci-runner.yaml
+++ b/.github/workflows/irap-fedora-ci-runner.yaml
@@ -1,0 +1,69 @@
+name: Build and Push atlas-irap-env container
+
+on:
+  push:
+    branches: 
+      - master
+    paths:
+      - "atlas-irap/**"
+  pull_request:
+    paths:
+      - "atlas-irap/**"
+
+jobs:
+  test:
+    name: Test build
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: atlas-irap
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Read tag
+      id: gettag
+      run: echo "::set-output name=tag::$(head -n 1 atlas-irap/image_tag | awk -F':' '{print $2}'
+
+    - name: Build image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.gettag.outputs.tag }}
+        containerfiles: |
+          ./atlas-irap/Dockerfile
+          
+  deploy:
+    name: Build and deploy image to quay.io/ebigxa
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: atlas-irap
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Read tag
+      id: gettag
+      run: echo "::set-output name=tag::$(head -n 1 atlas-irap/image_tag | awk -F':' '{print $2}'
+
+    - name: Build image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.gettag.outputs.tag }}
+        containerfiles: |
+          ./atlas-irap/Dockerfile
+    
+    - name: Push to Quay
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/ebigxa
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_TOKEN }}
+
+    - name: Use the image
+      run: echo "New image has been pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/irap-fedora/Dockerfile
+++ b/irap-fedora/Dockerfile
@@ -1,0 +1,3 @@
+FROM nunofonseca/irap_fedora:v1.0.3
+
+RUN yum update && yum -y install time

--- a/irap-fedora/image_tag
+++ b/irap-fedora/image_tag
@@ -1,0 +1,1 @@
+irap-fedora:v1.0.3+atlas0


### PR DESCRIPTION
This builds a new container with irap_fedora (Integrated RNA-Seq Analysis Pipeline) from Docker hub and adds new necessary functionality (time).  It also pushes the container to quay.io.

Unmerged parent PRs are:
https://github.com/ebi-gene-expression-group/atlas-containers/pull/57
https://github.com/ebi-gene-expression-group/atlas-containers/pull/58