### PR TITLE
Change workdir to opt for flyway installation

### DIFF
--- a/atlas-db-scxa-base/image_tag
+++ b/atlas-db-scxa-base/image_tag
@@ -1,1 +1,1 @@
-atlas-db-scxa-base:0.1.0
+atlas-db-scxa-base:0.1.1

--- a/atlas-db-scxa-base/post_install_dockerfile
+++ b/atlas-db-scxa-base/post_install_dockerfile
@@ -1,8 +1,10 @@
 USER root
+WORKDIR /opt
 RUN wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.3.2/flyway-commandline-6.3.2-linux-x64.tar.gz | tar xvz && ln -s `pwd`/flyway-6.3.2/flyway /opt/conda/bin
 # needed since atlas-schemas will copy stuff there
 RUN chmod a+w /usr/local
 RUN chown micromamba /opt/conda/bin/flyway
+WORKDIR /tmp
 USER micromamba
 
 ENV CONDA_PREFIX "/opt/conda"


### PR DESCRIPTION
This is to avoid flyway to be left on the /tmp, which is then mounted on top from the cluster filesystem by the singularity installation (flag --no-mount doesn't seem to work to avoid this on the cluster), leaving flyway useless when running there.