### PR TITLE
Avoid runner version update for 'null'

### DIFF
--- a/.github/workflows/github-actions-runner-detect-release.yaml
+++ b/.github/workflows/github-actions-runner-detect-release.yaml
@@ -15,7 +15,7 @@ jobs:
         id: getversion
         run: echo "::set-output name=version::$(grep 'ARG RUNNER_VERSION' github-actions-runner/Dockerfile | awk -F'=' '{print $2}')"
       - name: Update runner in container
-        if: steps.getrelease.outputs.release_tag != steps.getversion.outputs.version
+        if: steps.getrelease.outputs.release_tag != steps.getversion.outputs.version && steps.getrelease.outputs.release_tag != 'null'
         env:
           RELEASE_NO: ${{ steps.getrelease.outputs.release_tag }}
           CURRENT_VERSION: ${{ steps.getversion.outputs.version }}


### PR DESCRIPTION
The cron job that runs every hour is getting sometimes a `null` value. As it is different that current runner (numeric) version,
```
# Update latest runner
ARG RUNNER_VERSION=2.300.2
```
 it triggers erroneous PRs that are closed by the bot. Here we aim to fix that.