### PR TITLE
Update CLI to use latest version

### DIFF
--- a/atlas-db-scxa-base/image_tag
+++ b/atlas-db-scxa-base/image_tag
@@ -1,1 +1,1 @@
-atlas-db-scxa-base:0.1.2
+atlas-db-scxa-base:0.13.0

--- a/atlas-db-scxa-base/image_tag
+++ b/atlas-db-scxa-base/image_tag
@@ -1,1 +1,1 @@
-atlas-db-scxa-base:0.13.0
+atlas-db-scxa-base:0.15.0.0

--- a/atlas-db-scxa-base/templated-conda-env.yaml
+++ b/atlas-db-scxa-base/templated-conda-env.yaml
@@ -17,4 +17,4 @@ dependencies:
   - postgresql
   - nodejs
   - bats
-  - atlas-web-sc-cli=11.2
+  - atlas-web-sc-cli=v13.0.0

--- a/atlas-db-scxa-base/templated-conda-env.yaml
+++ b/atlas-db-scxa-base/templated-conda-env.yaml
@@ -17,4 +17,4 @@ dependencies:
   - postgresql
   - nodejs
   - bats
-  - atlas-web-sc-cli=v13.0.0
+  - atlas-web-sc-cli=11.2

--- a/atlas-db-scxa-base/templated-conda-env.yaml
+++ b/atlas-db-scxa-base/templated-conda-env.yaml
@@ -17,4 +17,4 @@ dependencies:
   - postgresql
   - nodejs
   - bats
-  - atlas-web-sc-cli=11.2
+  - atlas-web-sc-cli=15.0.0


### PR DESCRIPTION
Bump version of package `atlas-web-sc-cli` to enable setting an experiment design location independent of experiment files.

See https://github.com/ebi-gene-expression-group/db-scxa/pull/69.