### PR TITLE
Add python and pandas to db-scxa container

### DIFF
--- a/atlas-db-scxa-base/image_tag
+++ b/atlas-db-scxa-base/image_tag
@@ -1,1 +1,1 @@
-atlas-db-scxa-base:0.15.0.0
+atlas-db-scxa-base:0.15.1.0

--- a/atlas-db-scxa-base/templated-conda-env.yaml
+++ b/atlas-db-scxa-base/templated-conda-env.yaml
@@ -9,6 +9,8 @@ dependencies:
   - curl
   - wget
   - jq
+  - python=3.10
+  - pandas
   - r-base
   - r-tidyr
   - r-optparse


### PR DESCRIPTION
Adds Python and pandas to the db-scxa base container. This is so the added Python scripts in db-scxa repo can be tested in the CI.  [This is the PR](https://github.com/ebi-gene-expression-group/db-scxa/pull/76) that adds a Python script to the db-scxa repo, to fix the ingestion of externally analyised anndata experiments that do not have clusters.